### PR TITLE
Removed extra , in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "clean": "gatsby clean",
+    "clean": "gatsby clean"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I couldn't get gatsby build to work without removing that extra comma.  It looks like it's just a cleanup task.  